### PR TITLE
Update interface namespace for ext:dashboard

### DIFF
--- a/Classes/Dashboard/Provider/NewestPageviews.php
+++ b/Classes/Dashboard/Provider/NewestPageviews.php
@@ -23,7 +23,7 @@ namespace DanielSiepmann\Tracking\Dashboard\Provider;
 
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Dashboard\Widgets\Interfaces\ListDataProviderInterface;
+use TYPO3\CMS\Dashboard\Widgets\ListDataProviderInterface;
 
 class NewestPageviews implements ListDataProviderInterface
 {

--- a/Classes/Dashboard/Provider/PageviewsPerDay.php
+++ b/Classes/Dashboard/Provider/PageviewsPerDay.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Dashboard\WidgetApi;
-use TYPO3\CMS\Dashboard\Widgets\Interfaces\ChartDataProviderInterface;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 
 class PageviewsPerDay implements ChartDataProviderInterface
 {

--- a/Classes/Dashboard/Provider/PageviewsPerPage.php
+++ b/Classes/Dashboard/Provider/PageviewsPerPage.php
@@ -26,7 +26,7 @@ use Doctrine\DBAL\ParameterType;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Dashboard\WidgetApi;
-use TYPO3\CMS\Dashboard\Widgets\Interfaces\ChartDataProviderInterface;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 
 class PageviewsPerPage implements ChartDataProviderInterface
 {


### PR DESCRIPTION
As Interfaces was moved to a different namespace,
import statements need to be adjusted.