### PR TITLE
Remove HTML Tags from dashboard widget labels

### DIFF
--- a/Classes/Dashboard/Provider/PageviewsPerPage.php
+++ b/Classes/Dashboard/Provider/PageviewsPerPage.php
@@ -163,6 +163,6 @@ class PageviewsPerPage implements ChartDataProviderInterface
             $record = $this->pageRepository->getRecordOverlay('pages', $record, $sysLanguageUid);
         }
 
-        return BackendUtility::getRecordTitle('pages', $record, true);
+        return strip_tags(BackendUtility::getRecordTitle('pages', $record, true));
     }
 }

--- a/Classes/Dashboard/Provider/Recordviews.php
+++ b/Classes/Dashboard/Provider/Recordviews.php
@@ -216,7 +216,7 @@ class Recordviews implements ChartDataProviderInterface
         }
 
         return [
-            'title' => BackendUtility::getRecordTitle($table, $record, true),
+            'title' => strip_tags(BackendUtility::getRecordTitle($table, $record, true)),
             'type' => $record[$recordTypeField] ?? '',
         ];
     }


### PR DESCRIPTION
BackendUtility::getRecordTitle might contain HTML tags like "span".
Those might result in broken rendering. As we don't need this markup
anyway, we remove it.