### PR TITLE
Migrate phpunit configuration for 9.3.x

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,7 @@
+<?xml version="1.0"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     bootstrap="vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
@@ -11,7 +14,8 @@
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    verbose="false">
+    verbose="false"
+    >
 
     <testsuites>
         <testsuite name="unit">
@@ -22,11 +26,11 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">Classes</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <php>
         <env name="typo3DatabaseDriver" value="pdo_sqlite"/>


### PR DESCRIPTION
9.3.x renamed some options from offensive white and blacklist to include
and exclude.

As we don't want to wait until they get removed in v10, we adjust the
configuration now.