### PR TITLE
Add xmllinting of xml files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,47 @@ jobs:
       - name: Missing composer requirements
         run: ./vendor/bin/composer-require-checker
 
+  xml-linting:
+    runs-on: ubuntu-latest
+    needs: [check-composer]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+            echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: PHPUnit configuration file
+        run: xmllint --schema vendor/phpunit/phpunit/schema/9.3.xsd --noout phpunit.xml.dist
+
+      - name: PHPCodeSniffer configuration file
+        run: xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd --noout phpcs.xml.dist
+
+      - name: Fetch schema for xliff
+        run: wget https://raw.githubusercontent.com/TYPO3-Documentation/tea/master/.github/build/xliff-core-1.2-strict.xsd --output-document=.Build/xliff-core-1.2.xsd
+
+      - name: TYPO3 language files
+        run: xmllint --schema .Build/xliff-core-1.2.xsd --noout $(find Resources -name '*.xlf')
+
   coding-guideline:
     runs-on: ubuntu-latest
-    needs: [check-dependencies]
+    needs: 
+      - check-dependencies
+      - xml-linting
     steps:
       - uses: actions/checkout@v2
 
@@ -59,7 +97,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: [check-dependencies]
+    needs:
+      - check-dependencies
+      - xml-linting
     steps:
       - uses: actions/checkout@v2
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
-    <file source-language="en" datatype="plaintext">
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
         <header/>
         <body>
             <trans-unit id="dashboard.widget.group.tracking">

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
-    <file source-language="en" datatype="plaintext">
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
         <header/>
         <body>
             <trans-unit id="table.pageview">


### PR DESCRIPTION
The project has some xml files for configuration and for languages
(xliff).

Linting those files is added to CI to discover issues prior to merges.

As CI was a mess, it was split up into separate jobs.