### PR TITLE
Extend dependency checker to TYPO3 specific files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest --no-plugins
 
       - name: Missing composer requirements
-        run: ./vendor/bin/composer-require-checker
+        run: ./vendor/bin/composer-require-checker check --config-file dependency-checker.json
 
   xml-linting:
     runs-on: ubuntu-latest

--- a/dependency-checker.json
+++ b/dependency-checker.json
@@ -1,0 +1,8 @@
+{
+    "scan-files": [
+        "*.php",
+        "Configuration/*php",
+        "Configuration/Backend/*.php",
+        "Configuration/TCA/*.php"
+    ]
+}


### PR DESCRIPTION
Only autoloaded files will be checked by default.
TYPO3 has some additional files which should be scanned as well.