### PR TITLE
Add default and docs to not track preview

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -58,6 +58,7 @@ services:
     arguments:
       $rule: >
           not (context.getAspect("backend.user").isLoggedIn())
+          and not (context.getAspect("frontend.preview").isPreview())
           and not (request.getHeader("User-Agent")[0] matches "/^TYPO3|TYPO3 linkvalidator/")
           and not (request.getHeader("User-Agent")[0] matches "/Wget|curl|Go-http-client/")
           and not (request.getHeader("User-Agent")[0] matches "/Googlebot|Bingbot|bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Sogou|Exabot|NextCloud-News|Feedly|XING FeedReader|CCBot|SemrushBot|SEOkicks|Twitterbot|Seekport Crawler|SemanticScholarBot|ia_archiver|PaperLiBot|TrendsmapResolver|AhrefsBot|Nuzzel/")

--- a/Documentation/Pageview.rst
+++ b/Documentation/Pageview.rst
@@ -42,6 +42,7 @@ Let us examine an concrete example::
        arguments:
          $rule: >
              not (context.getAspect("backend.user").isLoggedIn())
+             and not (context.getAspect("frontend.preview").isPreview())
              and not (request.getHeader("User-Agent")[0] matches "/^TYPO3|TYPO3 linkvalidator/")
              and not (request.getHeader("User-Agent")[0] matches "/^Codeception Testing/")
              and not (request.getHeader("User-Agent")[0] matches "/Wget|curl|Go-http-client/")

--- a/Documentation/Recordview.rst
+++ b/Documentation/Recordview.rst
@@ -55,6 +55,7 @@ Let us examine an concrete example::
              matches: >
                  request.getQueryParams()["tx_news_pi1"] && request.getQueryParams()["tx_news_pi1"]["news"] > 0
                  and not (context.getAspect("backend.user").isLoggedIn())
+                 and not (context.getAspect("frontend.preview").isPreview())
                  and not (request.getHeader("User-Agent")[0] matches "/^TYPO3|TYPO3 linkvalidator/")
                  and not (request.getHeader("User-Agent")[0] matches "/Wget|curl|Go-http-client/")
                  and not (request.getHeader("User-Agent")[0] matches "/bot|spider|Slurp|Sogou|NextCloud-News|Feedly|XING FeedReader|SEOkicks|Seekport Crawler|ia_archiver|TrendsmapResolver|Nuzzel/")


### PR DESCRIPTION
Preview is also active if a preview link is shared via EXT:workspace.
Those views should probably not be tracked, just like active backend
sessions.