### PR TITLE
Raise from TYPO3 11.2 to 11.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           - '7.4'
           - '8.0'
         typo3-version:
-          - '11.2.*'
+          - '11.3.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -225,7 +225,7 @@ jobs:
           - '7.4'
           - '8.0'
         typo3-version:
-          - '11.2.*'
+          - '11.3.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -315,7 +315,7 @@ jobs:
           - '7.4'
           - '8.0'
         typo3-version:
-          - '11.2.*'
+          - '11.3.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -403,7 +403,7 @@ jobs:
           - '7.4'
           - '8.0'
         typo3-version:
-          - '11.2.*'
+          - '11.3.*'
     steps:
       - uses: actions/checkout@v2
 

--- a/Documentation/Changelog/1.1.2.rst
+++ b/Documentation/Changelog/1.1.2.rst
@@ -1,0 +1,30 @@
+1.1.2
+=====
+
+Breaking
+--------
+
+* No longer support v11.2 but v11.3
+
+  As this is latest release of v11 dev.
+  Only latest public release is supported.
+
+Features
+--------
+
+Nothing
+
+Fixes
+-----
+
+Nothing
+
+Tasks
+-----
+
+Nothing
+
+Deprecation
+-----------
+
+Nothing

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "psr/http-server-middleware": "^1.0",
         "symfony/console": "^5.2",
         "symfony/expression-language": "^5.2",
-        "typo3/cms-backend": "^10.4 || ~11.2",
-        "typo3/cms-core": "^10.4 || ~11.2",
-        "typo3/cms-dashboard": "^10.4 || ~11.2"
+        "typo3/cms-backend": "^10.4 || ~11.3",
+        "typo3/cms-core": "^10.4 || ~11.3",
+        "typo3/cms-dashboard": "^10.4 || ~11.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Only support latest public release of current TYPO3 dev releases.