### PR TITLE
Fix GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+          tools: composer:v2
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate composer.json
         run: composer validate
 
@@ -25,25 +34,27 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PHP lint
         run: "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l"
 
-  check-dependencies-TYPO3-v10:
+  check-dependencies:
     runs-on: ubuntu-latest
     needs:
       - check-composer
     strategy:
       matrix:
-        php-version:
-          # no 7.3
-          # maglnet/composer-require-checker has no compatible version
-          # - '7.3'
-          - '7.4'
-        typo3-version:
-          - '^10.4'
+        include:
+          - php-version: '7.4'
+            typo3-version: '^10.4'
+          - php-version: '7.4'
+            typo3-version: '11.4.*'
+          - php-version: '8.0'
+            typo3-version: '11.4.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -51,59 +62,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress --no-plugins "maglnet/composer-require-checker" "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
-
-      - name: Missing composer requirements
-        run: ./vendor/bin/composer-require-checker check --config-file dependency-checker.json
-
-  check-dependencies-TYPO3-v11:
-    runs-on: ubuntu-latest
-    needs:
-      - check-composer
-    strategy:
-      matrix:
-        php-version:
-          - '7.4'
-          - '8.0'
-        typo3-version:
-          - '11.4.*'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Install dependencies with expected TYPO3 version
         run: composer require --prefer-dist --no-progress --no-plugins "maglnet/composer-require-checker" "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
@@ -122,23 +84,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "7.4"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install xmllint
         run: sudo apt-get install libxml2-utils
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -161,20 +113,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "7.4"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -182,18 +124,22 @@ jobs:
       - name: Coding Guideline
         run: ./vendor/bin/ecs check
 
-  tests-sqlite-TYPO3-v10:
+  tests-sqlite:
     runs-on: ubuntu-latest
     needs:
-      - check-dependencies-TYPO3-v10
+      - check-dependencies
       - xml-linting
     strategy:
       matrix:
-        php-version:
-          - '7.3'
-          - '7.4'
-        typo3-version:
-          - '^10.4'
+        include:
+          - php-version: '7.3'
+            typo3-version: '^10.4'
+          - php-version: '7.4'
+            typo3-version: '^10.4'
+          - php-version: '7.4'
+            typo3-version: '11.4.*'
+          - php-version: '8.0'
+            typo3-version: '11.4.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -201,20 +147,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Install dependencies with expected TYPO3 version
         run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
@@ -222,18 +158,35 @@ jobs:
       - name: PHPUnit Tests
         run: ./vendor/bin/phpunit --testdox
 
-  tests-sqlite-TYPO3-v11:
+  tests-mysql:
     runs-on: ubuntu-latest
     needs:
-      - check-dependencies-TYPO3-v11
+      - check-dependencies
       - xml-linting
     strategy:
       matrix:
-        php-version:
-          - '7.4'
-          - '8.0'
-        typo3-version:
-          - '11.4.*'
+        include:
+          - db-version: '5.6'
+            php-version: '7.3'
+            typo3-version: '^10.4'
+          - db-version: '5.6'
+            php-version: '7.4'
+            typo3-version: '^10.4'
+          - db-version: '5.7'
+            php-version: '7.3'
+            typo3-version: '^10.4'
+          - db-version: '5.7'
+            php-version: '7.4'
+            typo3-version: '^10.4'
+          - db-version: '8'
+            php-version: '7.4'
+            typo3-version: '^10.4'
+          - db-version: '8'
+            php-version: '7.4'
+            typo3-version: '11.4.*'
+          - db-version: '8'
+            php-version: '8.0'
+            typo3-version: '11.4.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -241,63 +194,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
-
-      - name: PHPUnit Tests
-        run: ./vendor/bin/phpunit --testdox
-
-  tests-mysql-v5-TYPO3-v10:
-    runs-on: ubuntu-latest
-    needs:
-      - check-dependencies-TYPO3-v10
-      - xml-linting
-    strategy:
-      matrix:
-        db-version:
-          - '5.7'
-          - '5.6'
-        php-version:
-          - '7.3'
-          - '7.4'
-        typo3-version:
-          - '^10.4'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
@@ -318,19 +218,21 @@ jobs:
           export typo3DatabasePassword="root"
           ./vendor/bin/phpunit --testdox
 
-  tests-mysql-v8-TYPO3-v10:
+  code-quality:
     runs-on: ubuntu-latest
     needs:
-      - check-dependencies-TYPO3-v10
-      - xml-linting
+      - check-dependencies
     strategy:
       matrix:
-        db-version:
-          - '8'
-        php-version:
-          - '7.4'
-        typo3-version:
-          - '^10.4'
+        include:
+          - php-version: '7.3'
+            typo3-version: '^10.4'
+          - php-version: '7.4'
+            typo3-version: '^10.4'
+          - php-version: '7.4'
+            typo3-version: '11.4.*'
+          - php-version: '8.0'
+            typo3-version: '11.4.*'
     steps:
       - uses: actions/checkout@v2
 
@@ -338,166 +240,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          mysql version: '${{ matrix.db-version }}'
-          mysql database: 'typo3'
-          mysql root password: 'root'
-
-      - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
-
-      - name: PHPUnit Tests
-        run: |-
-          export typo3DatabaseDriver="pdo_mysql"
-          export typo3DatabaseName="typo3"
-          export typo3DatabaseHost="127.0.0.1"
-          export typo3DatabaseUsername="root"
-          export typo3DatabasePassword="root"
-          ./vendor/bin/phpunit --testdox
-
-  tests-mysql-v8-TYPO3-v11:
-    runs-on: ubuntu-latest
-    needs:
-      - check-dependencies-TYPO3-V11
-      - xml-linting
-    strategy:
-      matrix:
-        db-version:
-          - '8'
-        php-version:
-          - '7.4'
-          - '8.0'
-        typo3-version:
-          - '11.4.*'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          mysql version: '${{ matrix.db-version }}'
-          mysql database: 'typo3'
-          mysql root password: 'root'
-
-      - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
-
-      - name: PHPUnit Tests
-        run: |-
-          export typo3DatabaseDriver="pdo_mysql"
-          export typo3DatabaseName="typo3"
-          export typo3DatabaseHost="127.0.0.1"
-          export typo3DatabaseUsername="root"
-          export typo3DatabasePassword="root"
-          ./vendor/bin/phpunit --testdox
-
-  code-quality-TYPO3-v10:
-    runs-on: ubuntu-latest
-    needs:
-      - check-dependencies-TYPO3-v10
-    strategy:
-      matrix:
-        php-version:
-          - '7.3'
-          - '7.4'
-        typo3-version:
-          - '^10.4'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
-
-      - name: Code Quality (by PHPStan)
-        run: ./vendor/bin/phpstan analyse
-
-  code-quality-TYPO3-v11:
-    runs-on: ubuntu-latest
-    needs:
-      - check-dependencies-TYPO3-v11
-    strategy:
-      matrix:
-        php-version:
-          - '7.4'
-          - '8.0'
-        typo3-version:
-          - '11.4.*'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "${{ matrix.php-version }}"
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Install dependencies with expected TYPO3 version
         run: composer require --prefer-dist --no-progress "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"


### PR DESCRIPTION
Set COMPOSER_TOKEN in each step, as this broke some when.
Also disable "coverage", to improve speed, inspired from EXT:tea.
Use "include" to remove duplicate jobs with different versions, inspired
from EXT:tea.
Remove caches as they were not properly configured. Maybe add them later
inspired from EXT:tea?!