### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies with expected TYPO3 version
-        run: composer require --prefer-dist --no-progress --no-plugins "maglnet/composer-require-checker" "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
+        run: composer require --prefer-dist --no-progress --no-plugins "maglnet/composer-require-checker:^3.8" "typo3/cms-backend:${{ matrix.typo3-version }}" "typo3/cms-core:${{ matrix.typo3-version }}" "typo3/cms-dashboard:${{ matrix.typo3-version }}"
 
       - name: Missing composer requirements
         run: ./vendor/bin/composer-require-checker check --config-file dependency-checker.json

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^1.2",
+        "phpstan/phpstan": "^1.3",
         "phpstan/extension-installer": "^1.1",
         "jangregor/phpstan-prophecy": "^1.0",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -69,5 +69,13 @@
         "branch-alias": {
             "dev-main": "1.0.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true,
+            "cweagans/composer-patches": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,11 +6,14 @@ parameters:
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Ignore error for TYPO3 10 (ResultStatement) and TYPO3 11 (Statement)
+        # Ignore error for TYPO3 10 and TYPO3 11
         - '#Cannot call method fetch\(\) on Doctrine\\DBAL\\Driver\\Statement\|int\.#'
         - '#Cannot call method fetch\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int\.#'
+        - '#Cannot call method fetch\(\) on Doctrine\\DBAL\\Result\|int\.#'
         - '#Cannot call method fetchAll\(\) on Doctrine\\DBAL\\Driver\\Statement\|int\.#'
         - '#Cannot call method fetchAll\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int\.#'
+        - '#Cannot call method fetchAll\(\) on Doctrine\\DBAL\\Result\|int\.#'
         - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Driver\\Statement\|int\.#'
         - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int\.#'
+        - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Result\|int\.#'
         - '#^Variable \$_EXTKEY might not be defined\.$#'


### PR DESCRIPTION
- Support composer 2.2 new allow-plugins configuration

    In order to install all necessary composer plugins which we already trust.

- Allow installation of composer-require-checker again

    Require compatible version, no need to be to fancy.
    The given version is compatible with same set of combinations.
    We still ignore 7.3 as there is no compatible setup.

- Fix new PHPStan issues