### PR TITLE
Fix broken performance of list module

### DIFF
--- a/Documentation/Changelog/1.1.5.rst
+++ b/Documentation/Changelog/1.1.5.rst
@@ -1,0 +1,30 @@
+1.1.5
+=====
+
+Breaking
+--------
+
+Nothing
+
+Features
+--------
+
+Nothing
+
+Fixes
+-----
+
+* Fix broken performance of list module.
+  TYPO3 queries information of translations.
+  The fix adds database indices which are also applied for tt_content by TYPO3 itself.
+  This fixes slow loading times of the list module.
+
+Tasks
+-----
+
+Nothing
+
+Deprecation
+-----------
+
+Nothing

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE tx_tracking_pageview (
     type int(11) unsigned DEFAULT '0' NOT NULL,
 
     KEY page_views_per_page (pid,uid,crdate),
+    KEY language (l10n_parent,sys_language_uid),
 );
 
 CREATE TABLE tx_tracking_recordview (
@@ -14,4 +15,7 @@ CREATE TABLE tx_tracking_recordview (
     record varchar(255) DEFAULT '' NOT NULL,
     record_uid int(11) unsigned DEFAULT '0' NOT NULL,
     record_table_name varchar(255) DEFAULT '' NOT NULL,
+
+    KEY record_views_per_page (pid,uid,crdate),
+    KEY language (l10n_parent,sys_language_uid),
 );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,4 +16,5 @@ parameters:
         - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Driver\\Statement\|int\.#'
         - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Driver\\ResultStatement\|int\.#'
         - '#Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\Result\|int\.#'
+        - "#^Parameter \\#[0-9] \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
         - '#^Variable \$_EXTKEY might not be defined\.$#'


### PR DESCRIPTION
TYPO3 queries information of translations.
The fix adds database indices which are also applied for tt_content
by TYPO3 itself.
This fixes slow loading times of the list module.