### PR TITLE
Trigger CI on pull_request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,11 @@
 name: CI
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   check-composer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Foreign contributions did not trigger the CI.
This change will trigger CI also on foreign contributions (PRs).