### PR TITLE
Remove v12 upgrade findings

### DIFF
--- a/Classes/Domain/Repository/Pageview.php
+++ b/Classes/Domain/Repository/Pageview.php
@@ -107,6 +107,7 @@ class Pageview
             'crdate' => $pageview->getCrdate()->format('U'),
             'tstamp' => $pageview->getCrdate()->format('U'),
             'type' => $pageview->getPageType(),
+            // @extensionScannerIgnoreLine
             'sys_language_uid' => $pageview->getLanguage()->getLanguageId(),
             'url' => $pageview->getUrl(),
             'user_agent' => $pageview->getUserAgent(),

--- a/Classes/Domain/Repository/Recordview.php
+++ b/Classes/Domain/Repository/Recordview.php
@@ -53,6 +53,7 @@ class Recordview
             'pid' => $recordview->getPageUid(),
             'crdate' => $recordview->getCrdate()->format('U'),
             'tstamp' => $recordview->getCrdate()->format('U'),
+            // @extensionScannerIgnoreLine
             'sys_language_uid' => $recordview->getLanguage()->getLanguageId(),
             'url' => $recordview->getUrl(),
             'user_agent' => $recordview->getUserAgent(),

--- a/Configuration/TCA/tx_tracking_pageview.php
+++ b/Configuration/TCA/tx_tracking_pageview.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$tca = [
     'ctrl' => [
         'label' => 'url',
         'label_alt' => 'crdate',
@@ -8,7 +8,6 @@ return [
         'default_sortby' => 'crdate DESC',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
         'title' => 'LLL:EXT:tracking/Resources/Private/Language/locallang_tca.xlf:table.pageview',
@@ -32,9 +31,7 @@ return [
         'crdate' => [
             'label' => 'LLL:EXT:tracking/Resources/Private/Language/locallang_tca.xlf:table.pageview.crdate',
             'config' => [
-                'type' => 'input',
-                'eval' => 'datetime',
-                'renderType' => 'inputDateTime',
+                'type' => 'datetime',
             ],
         ],
         'sys_language_uid' => [
@@ -58,9 +55,8 @@ return [
         'type' => [
             'label' => 'LLL:EXT:tracking/Resources/Private/Language/locallang_tca.xlf:table.pageview.type',
             'config' => [
-                'type' => 'input',
+                'type' => 'number',
                 'readOnly' => true,
-                'eval' => 'int',
             ],
         ],
         'url' => [
@@ -73,3 +69,16 @@ return [
         ],
     ],
 ];
+
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+    $tca['ctrl']['cruser_id'] = 'cruser_id';
+
+    $tca['columns']['crdate']['config']['type'] = 'input';
+    $tca['columns']['crdate']['config']['renderType'] = 'inputDateTime';
+    $tca['columns']['crdate']['config']['eval'] = 'datetime';
+
+    $tca['columns']['type']['config']['type'] = 'input';
+    $tca['columns']['type']['config']['eval'] = 'int';
+}
+
+return $tca;

--- a/Configuration/TCA/tx_tracking_recordview.php
+++ b/Configuration/TCA/tx_tracking_recordview.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$tca = [
     'ctrl' => [
         'label' => 'record',
         'label_alt' => 'crdate',
@@ -8,7 +8,6 @@ return [
         'default_sortby' => 'crdate DESC',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
         'title' => 'LLL:EXT:tracking/Resources/Private/Language/locallang_tca.xlf:table.recordview',
@@ -32,9 +31,7 @@ return [
         'crdate' => [
             'label' => 'LLL:EXT:tracking/Resources/Private/Language/locallang_tca.xlf:table.recordview.crdate',
             'config' => [
-                'type' => 'input',
-                'eval' => 'datetime',
-                'renderType' => 'inputDateTime',
+                'type' => 'inputDateTime',
             ],
         ],
         'sys_language_uid' => [
@@ -75,3 +72,13 @@ return [
         ],
     ],
 ];
+
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+    $tca['ctrl']['cruser_id'] = 'cruser_id';
+
+    $tca['columns']['crdate']['config']['type'] = 'input';
+    $tca['columns']['crdate']['config']['renderType'] = 'inputDateTime';
+    $tca['columns']['crdate']['config']['eval'] = 'datetime';
+}
+
+return $tca;

--- a/Documentation/Changelog/2.5.1.rst
+++ b/Documentation/Changelog/2.5.1.rst
@@ -1,4 +1,4 @@
-2.6.0
+2.5.1
 =====
 
 Breaking
@@ -8,8 +8,6 @@ Nothing
 
 Features
 --------
-
-Nothing
 
 Fixes
 -----
@@ -26,6 +24,11 @@ Tasks
   Wait until server has started before executing tests.
 
 * Migrate test fixtures to PHP Data Sets using `codappix/typo3-php-datasets <https://packagist.org/packages/codappix/typo3-php-datasets>`_
+
+* Remove false positives of extension scanner in v12.
+
+* Remove TCA migrations in v12.
+  Stay compatible with v11 via condition within code.
 
 Deprecation
 -----------

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -90,4 +90,5 @@ in order to extract further information from them with future updates.
    Installation
    Pageview
    Recordview
+   Maintenance
    Changelog

--- a/Documentation/Maintenance.rst
+++ b/Documentation/Maintenance.rst
@@ -1,0 +1,14 @@
+Maintenance
+===========
+
+List of changes that need to be done for maintenance reasons.
+Those affect the extension itself, not users of the extension.
+
+E.g. changes once we drop a certain TYPO3 version.
+We might have new code backported for compatibility in older TYPO3 versions.
+Those changes are documented so we know what to do once we drop an older version.
+
+.. toctree::
+   :glob:
+
+   Maintenance/*

--- a/Documentation/Maintenance/v11.rst
+++ b/Documentation/Maintenance/v11.rst
@@ -1,0 +1,8 @@
+V11
+===
+
+Remove TCA fallback wrapped in version constraint in:
+
+- ``Configuration/TCA/tx_tracking_pageview.php``
+
+- ``Configuration/TCA/tx_tracking_recordview.php``


### PR DESCRIPTION
Ignore false positives for extension scanner.
Migrate TCA and keep old v11 within condition for backwards compatibility.

Closes: #110