### PR TITLE
Fix wrong recordview example configuration

### DIFF
--- a/Documentation/Recordview.rst
+++ b/Documentation/Recordview.rst
@@ -53,7 +53,7 @@ Let us examine an concrete example::
          $rules:
            news:
              matches: >
-                 request.getQueryParams()["tx_news_pi1"] && request.getQueryParams()["tx_news_pi1"]["news"] > 0
+                 traverse(request.getQueryParams(), "tx_news_pi1/news") > 0
                  and not (context.getAspect("backend.user").isLoggedIn())
                  and not (context.getAspect("frontend.preview").isPreview())
                  and traverse(request.getHeader("User-Agent"), '0')
@@ -61,7 +61,7 @@ Let us examine an concrete example::
                  and not (request.getHeader("User-Agent")[0] matches "/Wget|curl|Go-http-client/")
                  and not (request.getHeader("User-Agent")[0] matches "/bot|spider|Slurp|Sogou|NextCloud-News|Feedly|XING FeedReader|SEOkicks|Seekport Crawler|ia_archiver|TrendsmapResolver|Nuzzel/")
                  and not (request.getHeader("User-Agent")[0] matches "/mattermost|Slackbot|WhatsApp/")
-             recordUid: 'traverse(request.getQueryParams(), "tx_news_pi1", "news")'
+             recordUid: 'traverse(request.getQueryParams(), "tx_news_pi1/news")'
              tableName: 'tx_news_domain_model_news'
 
 The first paragraph will not be explained, check out :ref:`t3coreapi:configure-dependency-injection-in-extensions` instead.


### PR DESCRIPTION
The `traverse()` function takes two arguments where the 2nd is the full path with `/` as separator.
The example was wrong and not fully adopted.
The changelog already hold the correct information.

This is now adjusted, thanks to Andrea for reporting the issue.