### PR TITLE
Exclude tables from reference index

### DIFF
--- a/Classes/EventListener/ExcludeFromReferenceIndex.php
+++ b/Classes/EventListener/ExcludeFromReferenceIndex.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2025 Daniel Siepmann <daniel.siepmann@codappix.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace DanielSiepmann\Tracking\EventListener;
+
+use TYPO3\CMS\Core\DataHandling\Event\IsTableExcludedFromReferenceIndexEvent;
+
+final readonly class ExcludeFromReferenceIndex
+{
+    public function __invoke(
+        IsTableExcludedFromReferenceIndexEvent $event
+    ): void {
+        if (str_starts_with($event->getTable(), 'tx_tracking_')) {
+            $event->markAsExcluded();
+        }
+    }
+}

--- a/Classes/EventListener/ExcludeFromReferenceIndex.php
+++ b/Classes/EventListener/ExcludeFromReferenceIndex.php
@@ -25,7 +25,7 @@ namespace DanielSiepmann\Tracking\EventListener;
 
 use TYPO3\CMS\Core\DataHandling\Event\IsTableExcludedFromReferenceIndexEvent;
 
-final readonly class ExcludeFromReferenceIndex
+final class ExcludeFromReferenceIndex
 {
     public function __invoke(
         IsTableExcludedFromReferenceIndexEvent $event

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -71,6 +71,11 @@ services:
     arguments:
       $rules: []
 
+  DanielSiepmann\Tracking\EventListener\ExcludeFromReferenceIndex:
+    tags:
+      - name: 'event.listener'
+        event: 'TYPO3\CMS\Core\DataHandling\Event\IsTableExcludedFromReferenceIndexEvent'
+
   DanielSiepmann\Tracking\Command\UpdateDataCommand:
     tags:
       - name: 'console.command'

--- a/Documentation/Changelog/3.1.1.rst
+++ b/Documentation/Changelog/3.1.1.rst
@@ -1,0 +1,35 @@
+3.1.1
+=====
+
+Breaking
+--------
+
+Nothing
+
+Features
+--------
+
+Nothing
+
+Fixes
+-----
+
+* Exclude tables from reference index.
+
+  The tables can grow very fast depending on the number of visiting.
+  Also some installations keep the records for a long time.
+  That would make it nearly impossible to properly update the reference index.
+  Therefore the extension now excludes their tables by default.
+
+  One can prevent this, by removing the event listener e.g. via custom `Services.*`
+  files.
+
+Tasks
+-----
+
+Nothing
+
+Deprecation
+-----------
+
+Nothing


### PR DESCRIPTION
The tables can grow very fast depending on the number of visiting.  Also some installations keep the records for a long time.  That would make it nearly impossible to properly update the reference index.  Therefore the extension now excludes their tables by default.

One can prevent this, by removing the event listener e.g. via custom `Services.*` files.