### PR TITLE
Add composer dependency checker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,3 +198,40 @@ jobs:
 
       - name: Code Quality (by PHPStan)
         run: ./vendor/bin/phpstan analyse
+
+  composer-dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php-version: '8.1'
+            typo3-version: '^12.4'
+          - php-version: '8.2'
+            typo3-version: '^12.4'
+          - php-version: '8.3'
+            typo3-version: '^12.4'
+          - php-version: '8.4'
+            typo3-version: '^12.4'
+          - php-version: '8.2'
+            typo3-version: '^13.4'
+          - php-version: '8.3'
+            typo3-version: '^13.4'
+          - php-version: '8.4'
+            typo3-version: '^13.4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: none
+          tools: composer:v2
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies with expected TYPO3 version
+        run: composer require --prefer-dist --no-progress "typo3/cms-core:${{ matrix.typo3-version }}"
+
+      - name: Composer Dependencies
+        run: ./vendor/bin/composer-dependency-analyser

--- a/Classes/Dashboard/Provider/PageviewsPerDay.php
+++ b/Classes/Dashboard/Provider/PageviewsPerDay.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace DanielSiepmann\Tracking\Dashboard\Provider;
 
 use DanielSiepmann\Tracking\Extension;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -127,7 +127,7 @@ class PageviewsPerDay implements ChartDataProviderInterface
             ->orderBy('label', 'ASC')
         ;
         if (
-            (class_exists(SqlitePlatform::class) && $this->queryBuilder->getConnection()->getDatabasePlatform() instanceof SqlitePlatform)
+            (class_exists(SQLitePlatform::class) && $this->queryBuilder->getConnection()->getDatabasePlatform() instanceof SQLitePlatform)
             || (method_exists($this->queryBuilder->getConnection()->getDatabasePlatform(), 'getName') && $this->queryBuilder->getConnection()->getDatabasePlatform()->getName() === 'sqlite')
         ) {
             $this->queryBuilder->addSelectLiteral('date(crdate, "unixepoch") as "label"');

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.5",
         "saschaegerer/phpstan-typo3": "^1.10",
+        "shipmonk/composer-dependency-analyser": "^1.8",
         "typo3/testing-framework": "^8.0.9"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This is only for development to ensure proper dependency configuration within `composer.json`.