### PR TITLE
Remove phps dependency from nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,9 @@
 {
   pkgs ? import <nixpkgs> { }
-  ,phps ? import <phps>
 }:
 
 let
-  php = phps.packages.x86_64-linux.php84.buildEnv {
+  php = pkgs.php84.buildEnv {
     extensions = { enabled, all }: enabled ++ (with all; [
       xdebug
     ]);


### PR DESCRIPTION
Use system native PHP package API instead.
That way there is one dependency less.